### PR TITLE
Data structure changes

### DIFF
--- a/lib/Helper.js
+++ b/lib/Helper.js
@@ -3,7 +3,7 @@
 
   var Helper = {
     json: [],
-    data: null,
+    data: {},
     $ : null,
     dams : {}
   };
@@ -15,10 +15,10 @@
 
   Helper.buildJSON = function (cssSelector, key) {
     Helper.data.find(cssSelector).each(function (i, elem) {
-      Helper.json[i].data.push({
-        key : key,
-        value : Helper.$(elem).next().text()
-      });
+      Helper.json[i].data[key] = Helper.$(elem).next().text()
+      //var field = {}
+      //field[key] = Helper.$(elem).next().text()
+      //Helper.json[i].data.push(field)
     });
   };
 
@@ -32,21 +32,21 @@
       Helper.data.find('img').each(function (i, elem) {
         Helper.json[i] = {
           name : Helper.getDamName(elem.attribs.src),
-          data : []
+          data : {}
         };
       });
 
       // Fetch each td with content "volume armazenado"
-      Helper.buildJSON('td:contains(volume armazenado)', 'volume armazenado');
+      Helper.buildJSON('td:contains(volume armazenado)', 'volume_armazenado');
 
       // Fetch each td with content "pluviometria do dia"
-      Helper.buildJSON('td:contains(pluviometria do dia)', 'pluviometria do dia');
+      Helper.buildJSON('td:contains(pluviometria do dia)', 'pluviometria_do_dia');
 
       // Fetch each td with content "pluviometria acumulada no mês"
-      Helper.buildJSON('td:contains(pluviometria acumulada no mês)', 'pluviometria acumulada no mês');
+      Helper.buildJSON('td:contains(pluviometria acumulada no mês)', 'pluviometria_acumulada_mes');
 
       // Fetch each td with content "média histórica do mês"
-      Helper.buildJSON('td:contains(média histórica do mês)', 'média histórica do mês');
+      Helper.buildJSON('td:contains(média histórica do mês)', 'media_historica_mes');
     });
 
     return Helper.json;

--- a/lib/Helper.js
+++ b/lib/Helper.js
@@ -16,9 +16,6 @@
   Helper.buildJSON = function (cssSelector, key) {
     Helper.data.find(cssSelector).each(function (i, elem) {
       Helper.json[i].data[key] = Helper.$(elem).next().text()
-      //var field = {}
-      //field[key] = Helper.$(elem).next().text()
-      //Helper.json[i].data.push(field)
     });
   };
 

--- a/lib/Helper.js
+++ b/lib/Helper.js
@@ -37,7 +37,7 @@
       Helper.buildJSON('td:contains(volume armazenado)', 'volume_armazenado');
 
       // Fetch each td with content "pluviometria do dia"
-      Helper.buildJSON('td:contains(pluviometria do dia)', 'pluviometria_do_dia');
+      Helper.buildJSON('td:contains(pluviometria do dia)', 'pluviometria_dia');
 
       // Fetch each td with content "pluviometria acumulada no mês"
       Helper.buildJSON('td:contains(pluviometria acumulada no mês)', 'pluviometria_acumulada_mes');


### PR DESCRIPTION
Change json data structure so that instead of data being an array of
unitary objects it is now an object with key: value pairs of
information such as volume_armazenado: volume, pluviometria_do_dia:
pluviometria. For example:
[
   {
      "name": "Cantareira",
      "data": {
         "volume_armazenado": "8,9 %",
         "pluviometria_do_dia": "28,6 mm",
         "pluviometria_acumulada_mes": "257,0 mm",
         "media_historica_mes": "199,1 mm"
      }
   },
   {
      "name": "Alto Tietê",
      "data": {
         "volume_armazenado": "16,3 %",
         "pluviometria_do_dia": "51,1 mm",
         "pluviometria_acumulada_mes": "268,1 mm",
         "media_historica_mes": "192,0 mm"
      }
   },... 

No major changes in the other 2 commits - I had forgotten the old code commented.

Those new key names made it possible to even load the json into a python application and use them directly in a dictionary like: 
j[0]['data']['pluviometria_acumulada_mes']
'257,0 mm'
